### PR TITLE
Fix container not fully shown at heights < 700px

### DIFF
--- a/modules/database/backup/modal/BackupList.tsx
+++ b/modules/database/backup/modal/BackupList.tsx
@@ -11,7 +11,7 @@ const Container = styled.ul`
   padding: 0;
   margin: 0;
 
-  max-height: 420px;
+  max-height: 50vh;
   overflow-x: hidden;
 `
 


### PR DESCRIPTION
When the backup list is full, the container extends and you cannot see the button controls on certain devices (with browser heights under 700px)