### PR TITLE
📄 Bumped copyright year to 2021

### DIFF
--- a/common/page/Footer.tsx
+++ b/common/page/Footer.tsx
@@ -101,7 +101,7 @@ export function Footer() {
         </NavigationItem>
       </NavigationList>
       <LegalInfo>
-        &copy; 2020 The Discohook Authors. Discohook is not affiliated with
+        &copy; 2020-2021 The Discohook Authors. Discohook is not affiliated with
         Discord.
       </LegalInfo>
       <LegalInfo>

--- a/common/page/Footer.tsx
+++ b/common/page/Footer.tsx
@@ -101,7 +101,7 @@ export function Footer() {
         </NavigationItem>
       </NavigationList>
       <LegalInfo>
-        &copy; 2020-2021 The Discohook Authors. Discohook is not affiliated with
+        &copy; 2021 The Discohook Authors. Discohook is not affiliated with
         Discord.
       </LegalInfo>
       <LegalInfo>


### PR DESCRIPTION
Just a minor change. While the year on a website's copyright doesn't enforce much, it still makes it feel more "up to date", and assures users the website is being actively maintained. 