### PR TITLE
Update theme colors

### DIFF
--- a/common/input/button/PrimaryButton.ts
+++ b/common/input/button/PrimaryButton.ts
@@ -1,4 +1,4 @@
-import { shade, tint } from "polished"
+import { rgb } from "polished"
 import styled from "styled-components"
 import { DARK_THEME } from "../../theming/darkTheme"
 import type { Theme } from "../../theming/Theme"
@@ -11,9 +11,9 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
 
   &:hover {
     background: ${({ theme, accent = "primary" }) =>
-      tint(0.2, theme.accent[accent])};
+      rgb(71, 82, 196)};
     border-color: ${({ theme, accent = "primary" }) =>
-      tint(0.2, theme.accent[accent])};
+      rgb(71, 82, 196)};
   }
 
   &:focus {
@@ -22,15 +22,9 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
 
   &:active {
     background: ${({ theme, accent = "primary" }) =>
-      shade(
-        theme.appearance.color === "dark" ? 0.3 : 0.1,
-        theme.accent[accent],
-      )};
+      rgb(60, 69, 165)};
     border-color: ${({ theme, accent = "primary" }) =>
-      shade(
-        theme.appearance.color === "dark" ? 0.3 : 0.1,
-        theme.accent[accent],
-      )};
+      rgb(60, 69, 165)};
   }
 
   &:disabled {

--- a/common/input/button/PrimaryButton.ts
+++ b/common/input/button/PrimaryButton.ts
@@ -10,10 +10,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   color: ${DARK_THEME.header.primary};
 
   &:hover {
-    background: ${({ theme, accent = "primary" }) =>
-      rgb(71, 82, 196)};
-    border-color: ${({ theme, accent = "primary" }) =>
-      rgb(71, 82, 196)};
+    background: ${({ theme, accent = "primary" }) => rgb(71, 82, 196)};
+    border-color: ${({ theme, accent = "primary" }) => rgb(71, 82, 196)};
   }
 
   &:focus {
@@ -21,10 +19,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   }
 
   &:active {
-    background: ${({ theme, accent = "primary" }) =>
-      rgb(60, 69, 165)};
-    border-color: ${({ theme, accent = "primary" }) =>
-      rgb(60, 69, 165)};
+    background: ${({ theme, accent = "primary" }) => rgb(60, 69, 165)};
+    border-color: ${({ theme, accent = "primary" }) => rgb(60, 69, 165)};
   }
 
   &:disabled {

--- a/common/input/button/PrimaryButton.ts
+++ b/common/input/button/PrimaryButton.ts
@@ -10,8 +10,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   color: ${DARK_THEME.header.primary};
 
   &:hover {
-    background: ${({ theme, accent = "primary" }) => rgb(71, 82, 196)};
-    border-color: ${({ theme, accent = "primary" }) => rgb(71, 82, 196)};
+    background: ${({}) => rgb(71, 82, 196)};
+    border-color: ${({}) => rgb(71, 82, 196)};
   }
 
   &:focus {
@@ -19,8 +19,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   }
 
   &:active {
-    background: ${({ theme, accent = "primary" }) => rgb(60, 69, 165)};
-    border-color: ${({ theme, accent = "primary" }) => rgb(60, 69, 165)};
+    background: ${({}) => rgb(60, 69, 165)};
+    border-color: ${({}) => rgb(60, 69, 165)};
   }
 
   &:disabled {

--- a/common/input/button/PrimaryButton.ts
+++ b/common/input/button/PrimaryButton.ts
@@ -10,8 +10,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   color: ${DARK_THEME.header.primary};
 
   &:hover {
-    background: ${({}) => rgb(71, 82, 196)};
-    border-color: ${({}) => rgb(71, 82, 196)};
+    background: ${rgb(71, 82, 196)};
+    border-color: ${rgb(71, 82, 196)};
   }
 
   &:focus {
@@ -19,8 +19,8 @@ export const PrimaryButton = styled(Button)<{ accent?: keyof Theme["accent"] }>`
   }
 
   &:active {
-    background: ${({}) => rgb(60, 69, 165)};
-    border-color: ${({}) => rgb(60, 69, 165)};
+    background: ${rgb(60, 69, 165)};
+    border-color: ${rgb(60, 69, 165)};
   }
 
   &:disabled {

--- a/common/theming/commonTheme.ts
+++ b/common/theming/commonTheme.ts
@@ -3,7 +3,7 @@ import type { Theme } from "./Theme"
 
 export const COMMON_THEME: Pick<Theme, "discord" | "font"> = {
   discord: {
-    primary: rgb(114, 137, 218),
+    primary: rgb(88, 101, 242),
     success: rgb(67, 181, 129),
     warning: rgb(250, 166, 26),
     danger: rgb(240, 71, 71),


### PR DESCRIPTION
The PrimaryButton hover & active colors I used are from a component button with the "primary" style (but this type of button can also been seen in settings with "Edit Profile" and a couple other places). They're the same on both light and dark modes, so I figured it wasn't necessary to have the tint/shade based on current theme and just used static values instead.