### PR TITLE
Update mention colors & clock cursor

### DIFF
--- a/modules/markdown/styles/Mention.ts
+++ b/modules/markdown/styles/Mention.ts
@@ -15,15 +15,15 @@ export const Mention = styled.span`
 
   color: ${({ theme }) =>
     theme.appearance.color === "dark"
-      ? rgb(255, 255, 255)
+      ? rgb(222, 224, 252)
       : theme.discord.primary};
 
   font-weight: 500;
-  transition: background 50ms ease-out;
+  transition: background 50ms ease-out, color 50ms ease-out;
 
   &:hover {
     background: ${DARK_THEME.discord.primary};
-    color: ${rgb(255, 255, 255)};
-    transition: background 50ms ease-out;
+    color: ${rgb(222, 224, 252)};
+    transition: background 50ms ease-out, color 50ms ease-out;
   }
 `

--- a/modules/markdown/styles/Mention.ts
+++ b/modules/markdown/styles/Mention.ts
@@ -11,9 +11,7 @@ export const Mention = styled.span`
   background: ${({ theme }) =>
     theme.appearance.color === "dark"
       ? transparentize(0.7, theme.discord.primary)
-      : theme.appearance.color === "light"
-      ? transparentize(0.85, theme.discord.primary)
-      : tint(0.9, theme.discord.primary)};
+      : transparentize(0.85, theme.discord.primary)};
 
   color: ${({ theme }) =>
     theme.appearance.color === "dark"

--- a/modules/markdown/styles/Mention.ts
+++ b/modules/markdown/styles/Mention.ts
@@ -19,11 +19,11 @@ export const Mention = styled.span`
       : theme.discord.primary};
 
   font-weight: 500;
-  transition: background 50ms ease-out, color 50ms ease-out;
+  transition: 50ms ease-out;
+  transition-property: background-color, color;
 
   &:hover {
     background: ${DARK_THEME.discord.primary};
     color: ${DARK_THEME.header.primary};
-    transition: background 50ms ease-out, color 50ms ease-out;
   }
 `

--- a/modules/markdown/styles/Mention.ts
+++ b/modules/markdown/styles/Mention.ts
@@ -1,4 +1,4 @@
-import { tint, transparentize, rgb } from "polished"
+import { transparentize, rgb } from "polished"
 import styled from "styled-components"
 import { DARK_THEME } from "../../../common/theming/darkTheme"
 

--- a/modules/markdown/styles/Mention.ts
+++ b/modules/markdown/styles/Mention.ts
@@ -1,4 +1,4 @@
-import { tint, transparentize } from "polished"
+import { tint, transparentize, rgb } from "polished"
 import styled from "styled-components"
 import { DARK_THEME } from "../../../common/theming/darkTheme"
 
@@ -10,18 +10,22 @@ export const Mention = styled.span`
 
   background: ${({ theme }) =>
     theme.appearance.color === "dark"
-      ? transparentize(0.9, theme.discord.primary)
+      ? transparentize(0.7, theme.discord.primary)
+      : theme.appearance.color === "light"
+      ? transparentize(0.85, theme.discord.primary)
       : tint(0.9, theme.discord.primary)};
 
-  color: ${({ theme }) => theme.discord.primary};
+  color: ${({ theme }) =>
+    theme.appearance.color === "dark"
+      ? rgb(255, 255, 255)
+      : theme.discord.primary};
+
   font-weight: 500;
+  transition: background 50ms ease-out;
 
   &:hover {
-    background: ${({ theme }) =>
-      theme.appearance.color === "dark"
-        ? transparentize(0.3, theme.discord.primary)
-        : theme.discord.primary};
-
-    color: ${DARK_THEME.header.primary};
+    background: ${DARK_THEME.discord.primary};
+    color: ${rgb(255, 255, 255)};
+    transition: background 50ms ease-out;
   }
 `

--- a/modules/message/preview/Clock.tsx
+++ b/modules/message/preview/Clock.tsx
@@ -14,11 +14,11 @@ const Display = styled.span`
     theme.appearance.display === "cozy" &&
     css`
       margin-left: ${rem(4)};
-
       font-size: ${rem(12)};
       font-weight: 500;
       line-height: ${rem(22)};
       vertical-align: baseline;
+      cursor: default;
     `};
 
   ${({ theme }) =>
@@ -26,11 +26,11 @@ const Display = styled.span`
     css`
       width: ${rem(48)};
       margin-right: ${rem(8)};
-
       font-size: ${rem(11)};
       line-height: ${rem(22)};
       text-align: right;
       text-indent: 0;
+      cursor: default;
     `};
 `
 

--- a/modules/message/preview/Clock.tsx
+++ b/modules/message/preview/Clock.tsx
@@ -7,6 +7,7 @@ import { formatTimestamp } from "./formatTimestamp"
 const Display = styled.span`
   display: inline-block;
   height: ${rem(20)};
+  cursor: default;
 
   color: ${({ theme }) => theme.text.muted};
 
@@ -14,11 +15,11 @@ const Display = styled.span`
     theme.appearance.display === "cozy" &&
     css`
       margin-left: ${rem(4)};
+
       font-size: ${rem(12)};
       font-weight: 500;
       line-height: ${rem(22)};
       vertical-align: baseline;
-      cursor: default;
     `};
 
   ${({ theme }) =>
@@ -26,11 +27,11 @@ const Display = styled.span`
     css`
       width: ${rem(48)};
       margin-right: ${rem(8)};
+
       font-size: ${rem(11)};
       line-height: ${rem(22)};
       text-align: right;
       text-indent: 0;
-      cursor: default;
     `};
 `
 


### PR DESCRIPTION
Transparency levels were taken from the client (variable `--brand-experiment-30a` for dark mode and `--brand-experiment-15a` for light). ~~I wasn't able to get the background transitions exactly right (the text looks a bit weird mid-transition on light theme) but I hope it's close enough. Would've taken a gif to demonstrate but sharex records at a fairly low framerate which makes it hard to tell.~~ fixed in cbdf02c

Clock cursor is a small change; it's just the default arrow in the client