### PR TITLE
Added a transparent value for the embed color inputfield.

### DIFF
--- a/common/input/color/ColorInputField.tsx
+++ b/common/input/color/ColorInputField.tsx
@@ -73,7 +73,10 @@ export function ColorInputField(props: ColorInputProps) {
 
         if (/^#?[\da-f]{6}$/i.test(value)) {
           color.setHex(value)
-        } else if (!value) {
+        }else if(value == 'transparent'){
+          color.setHex('#2f3136')
+        } 
+        else if (!value) {
           color.invalidate()
         } else {
           const match = RGB_STRING_RE.exec(value)
@@ -88,7 +91,7 @@ export function ColorInputField(props: ColorInputProps) {
         setValue(color.hex ?? "")
       }}
       label={label}
-      placeholder="#rrggbb"
+      placeholder="#rrggbb or transparent"
       onClick={() => {
         popover.spawn()
       }}


### PR DESCRIPTION
The backgroundColor of the embed has a hexcode of "#2f3136". When a user types "transparent" in the color inputfield it will be replaced with the background hexcode to make it look like the border is transparent.