### PR TITLE
Fix weird edit behavior when the message has attachments

### DIFF
--- a/modules/message/state/data/MessageData.ts
+++ b/modules/message/state/data/MessageData.ts
@@ -6,5 +6,5 @@ export type MessageData = {
   readonly username?: string
   readonly avatar_url?: string
   readonly files?: readonly File[]
-  readonly attachments?: readonly []
+  readonly attachments?: readonly unknown[]
 }

--- a/modules/message/state/data/MessageData.ts
+++ b/modules/message/state/data/MessageData.ts
@@ -6,5 +6,5 @@ export type MessageData = {
   readonly username?: string
   readonly avatar_url?: string
   readonly files?: readonly File[]
-  readonly attachments?: readonly Object[]
+  readonly attachments?: readonly []
 }

--- a/modules/message/state/data/MessageData.ts
+++ b/modules/message/state/data/MessageData.ts
@@ -6,4 +6,5 @@ export type MessageData = {
   readonly username?: string
   readonly avatar_url?: string
   readonly files?: readonly File[]
+  readonly attachments?: readonly Object[]
 }

--- a/modules/message/state/models/MessageModel.ts
+++ b/modules/message/state/models/MessageModel.ts
@@ -46,6 +46,7 @@ export const MessageModel = types
         username: self.username || undefined,
         avatar_url: self.avatar || undefined,
         files: self.files.length > 0 ? Array.from(self.files) : undefined,
+        attachments: self.files.length < 1 ? [] : undefined,
       }
     },
 

--- a/modules/message/state/models/MessageModel.ts
+++ b/modules/message/state/models/MessageModel.ts
@@ -46,7 +46,7 @@ export const MessageModel = types
         username: self.username || undefined,
         avatar_url: self.avatar || undefined,
         files: self.files.length > 0 ? Array.from(self.files) : undefined,
-        attachments: self.files.length < 1 ? [] : undefined,
+        attachments: self.files.length === 0 ? [] : undefined,
       }
     },
 

--- a/modules/webhook/WebhookModel.ts
+++ b/modules/webhook/WebhookModel.ts
@@ -53,13 +53,13 @@ export const WebhookModel = types
 
         return [
           "PATCH",
-          `https://${host}/api/v8/webhooks/${self.snowflake}/${self.token}/messages/${messageId}`,
+          `https://${host}/api/v10/webhooks/${self.snowflake}/${self.token}/messages/${messageId}`,
         ]
       }
 
       return [
         "POST",
-        `https://${host}/api/v8/webhooks/${self.snowflake}/${self.token}?wait=true`,
+        `https://${host}/api/v10/webhooks/${self.snowflake}/${self.token}?wait=true`,
       ]
     },
   }))


### PR DESCRIPTION
The site now includes `attachments: []` when no files are present in the editor. The edit message route's API version was also updated so we do not need to worry about infinitely adding attachments either.

Unfortunately this comes with the side effect of no longer "supporting" multiple attachments.