### PR TITLE
Add support for thread_id parameter.

### DIFF
--- a/modules/webhook/WebhookModel.ts
+++ b/modules/webhook/WebhookModel.ts
@@ -48,19 +48,29 @@ export const WebhookModel = types
 
       const match = reference && MESSAGE_REF_RE.exec(reference)
 
+      const threadParam = new URL(self.url).searchParams.get("thread_id")
+
       if (match) {
         const [, messageId] = match
 
-        return [
-          "PATCH",
+        const routeUrl = new URL(
           `https://${host}/api/v10/webhooks/${self.snowflake}/${self.token}/messages/${messageId}`,
-        ]
+        )
+        if (threadParam) {
+          routeUrl.searchParams.set("thread_id", threadParam)
+        }
+
+        return ["PATCH", String(routeUrl)]
       }
 
-      return [
-        "POST",
+      const routeUrl = new URL(
         `https://${host}/api/v10/webhooks/${self.snowflake}/${self.token}?wait=true`,
-      ]
+      )
+      if (threadParam) {
+        routeUrl.searchParams.set("thread_id", threadParam)
+      }
+
+      return ["POST", String(routeUrl)]
     },
   }))
   .actions(self => ({

--- a/modules/webhook/constants.ts
+++ b/modules/webhook/constants.ts
@@ -33,6 +33,6 @@ export const DEFAULT_AVATAR_URL =
 export const BRANDED_DEFAULT_AVATAR_URL = "/static/discord-avatar.png"
 export const DEFAULT_DISPLAY_NAME = "Discohook"
 
-export const WEBHOOK_URL_RE = /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/api(?:\/v\d+)?\/webhooks\/\d+\/[\w-]+$/
+export const WEBHOOK_URL_RE = /^https?:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/api(?:\/v\d+)?\/webhooks\/\d+\/[\w-]+(?:\?thread_id=\d+)?$/
 
 export const MESSAGE_REF_RE = /^(?:https:\/\/(?:www\.|ptb\.|canary\.)?discord(?:app)?\.com\/channels\/\d+\/\d+\/)?(\d+)$/


### PR DESCRIPTION
Closes #59 

This implements basic support for threads in the site by directly adding the `thread_id` URL parameter to the webhook URL. 

Below is a screenshot of a successful thread message being sent and edited.

![image](https://user-images.githubusercontent.com/29337040/164912897-50861435-c555-41fc-a9ca-38a8af46afd4.png)

![image](https://user-images.githubusercontent.com/29337040/164912903-b1a16d59-cc18-450f-a057-e50e245a8324.png)