### PR TITLE
Support message flags

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,7 +109,7 @@ module.exports = {
     "new-cap": "warn",
     "no-alert": "error",
     "no-await-in-loop": "warn",
-    "no-bitwise": "warn",
+    "no-bitwise": ["warn", { allow: ["|=", "<<"] }],
     "no-caller": "warn",
     "no-case-declarations": "error",
     "no-compare-neg-zero": "error",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -109,7 +109,6 @@ module.exports = {
     "new-cap": "warn",
     "no-alert": "error",
     "no-await-in-loop": "warn",
-    "no-bitwise": ["warn", { allow: ["|=", "<<"] }],
     "no-caller": "warn",
     "no-case-declarations": "error",
     "no-compare-neg-zero": "error",

--- a/common/input/checkable/Checkbox.tsx
+++ b/common/input/checkable/Checkbox.tsx
@@ -6,6 +6,7 @@ import { CheckableButton } from "./layout/CheckableButton"
 import { CheckableContainer } from "./layout/CheckableContainer"
 import { CheckableInput } from "./layout/CheckableInput"
 import { CheckableLabel } from "./layout/CheckableLabel"
+import { LabelDescription } from "./layout/LabelDescription"
 import { Positioner } from "./layout/Positioner"
 
 const Button = styled(CheckableButton)`
@@ -32,6 +33,7 @@ export type CheckboxProps = {
   onChange: (value: boolean) => void
   className?: string
   disabled?: boolean
+  description?: string
 }
 
 export function Checkbox(props: CheckboxProps) {
@@ -42,6 +44,7 @@ export function Checkbox(props: CheckboxProps) {
     onChange: handleChange,
     className,
     disabled,
+    description,
   } = props
 
   return (
@@ -56,7 +59,11 @@ export function Checkbox(props: CheckboxProps) {
         />
         <Button>{check}</Button>
       </Positioner>
-      <CheckableLabel htmlFor={id}>{label}</CheckableLabel>
+        <CheckableLabel htmlFor={id}>
+          {label}
+          {description && <LabelDescription>{description}</LabelDescription>}
+        </CheckableLabel>
+      
     </CheckableContainer>
   )
 }

--- a/common/input/checkable/Checkbox.tsx
+++ b/common/input/checkable/Checkbox.tsx
@@ -59,11 +59,10 @@ export function Checkbox(props: CheckboxProps) {
         />
         <Button>{check}</Button>
       </Positioner>
-        <CheckableLabel htmlFor={id}>
-          {label}
-          {description && <LabelDescription>{description}</LabelDescription>}
-        </CheckableLabel>
-      
+      <CheckableLabel htmlFor={id}>
+        {label}
+        {description && <LabelDescription>{description}</LabelDescription>}
+      </CheckableLabel>
     </CheckableContainer>
   )
 }

--- a/common/input/checkable/layout/CheckableButton.ts
+++ b/common/input/checkable/layout/CheckableButton.ts
@@ -4,6 +4,7 @@ import styled from "styled-components"
 export const CheckableButton = styled.div`
   ${cover()};
   ${size("100%")};
+  min-width: 16px;
 
   background: ${({ theme }) => theme.background.secondaryAlt};
   border: 2px solid ${({ theme }) => theme.background.secondaryAlt};

--- a/common/input/checkable/layout/CheckableContainer.ts
+++ b/common/input/checkable/layout/CheckableContainer.ts
@@ -4,7 +4,8 @@ export const CheckableContainer = styled.div`
   display: flex;
   align-items: center;
 
-  height: 36px;
+  padding-top: 2px;
+  padding-bottom: 2px;
 
   user-select: none;
 `

--- a/common/input/checkable/layout/LabelDescription.tsx
+++ b/common/input/checkable/layout/LabelDescription.tsx
@@ -1,0 +1,9 @@
+import styled from "styled-components"
+
+export const LabelDescription = styled.p`
+  color: ${({ theme }) => theme.text.normal};
+  font-size: 15px;
+  font-weight: 500;
+
+  margin: 4px 0 0;
+`

--- a/modules/editor/data/validation/isMessage.ts
+++ b/modules/editor/data/validation/isMessage.ts
@@ -1,6 +1,7 @@
 import { contains } from "./contains"
 import { first } from "./first"
 import { isEmbed } from "./isEmbed"
+import { isNumber } from "./isNumber"
 import { isShape } from "./isShape"
 import { isString } from "./isString"
 import { isUrl } from "./isUrl"
@@ -19,6 +20,7 @@ export const isMessage: Validator = first(
     "avatar_url",
     "attachments",
     "thread_name",
+    "flags",
   ),
   requiresKey("content", "embeds"),
   isShape({
@@ -27,5 +29,6 @@ export const isMessage: Validator = first(
     username: optional(first(isString, length(1, 256))),
     avatar_url: optional(isUrl),
     thread_name: optional(first(isString, length(1, 100))),
+    flags: optional(isNumber),
   }),
 )

--- a/modules/editor/message/PrimaryContentEditor.tsx
+++ b/modules/editor/message/PrimaryContentEditor.tsx
@@ -1,5 +1,6 @@
 import { useObserver } from "mobx-react-lite"
 import React from "react"
+import { Checkbox } from "../../../common/input/checkable/Checkbox"
 import { InputError } from "../../../common/input/error/InputError"
 import { FileInputField } from "../../../common/input/file/FileInputField"
 import { InputField } from "../../../common/input/text/InputField"
@@ -72,6 +73,24 @@ export function PrimaryContentEditor(props: PrimaryContentEditorProps) {
                 ? "You cannot change thread names using webhooks"
                 : undefined
             }
+          />
+        </Stack>
+      </Section>
+      <Section name="Flags">
+        <Stack gap={12}>
+          <Checkbox
+            id={`_${message.id}_suppress_embeds`}
+            label="Suppress Embeds"
+            description='Hides link embeds. This cannot be used in conjunction with rich embeds (created with "Add Embed").'
+            error={form.field("flags_suppress_embeds").error}
+            {...form.field("flags_suppress_embeds").inputProps}
+          />
+          <Checkbox
+            id={`_${message.id}_suppress_notifications`}
+            label="Suppress Notifications"
+            description='If the message contains mentions in its "Content" field, this prevents Discord from sending out notifications when it is sent.'
+            error={form.field("flags_suppress_notifications").error}
+            {...form.field("flags_suppress_notifications").inputProps}
           />
         </Stack>
       </Section>

--- a/modules/message/state/data/MessageData.ts
+++ b/modules/message/state/data/MessageData.ts
@@ -8,4 +8,5 @@ export type MessageData = {
   readonly files?: readonly File[]
   readonly attachments?: readonly unknown[]
   readonly thread_name?: string | null
+  readonly flags?: number
 }

--- a/modules/message/state/editorForm.ts
+++ b/modules/message/state/editorForm.ts
@@ -116,6 +116,12 @@ export const editorForm = new Form(EditorManager, {
       controlled: controlled.object,
       validators: [maxLength(100)],
     }),
+    flags_suppress_embeds: new Field(converters.boolean, {
+      controlled: controlled.object,
+    }),
+    flags_suppress_notifications: new Field(converters.boolean, {
+      controlled: controlled.object,
+    }),
     reference: new Field(converters.string, {
       controlled: controlled.object,
       validators: [matchesRegex(MESSAGE_REF_RE, "Invalid message link")],

--- a/modules/message/state/models/MessageModel.ts
+++ b/modules/message/state/models/MessageModel.ts
@@ -18,6 +18,8 @@ export const MessageModel = types
     reference: "",
     timestamp: types.optional(nullableDate, null),
     badge: types.optional(types.maybeNull(types.string), "Bot"),
+    flags_suppress_embeds: types.optional(types.boolean, false),
+    flags_suppress_notifications: types.optional(types.boolean, false), // silent
   })
   .volatile(() => ({
     files: [] as readonly File[],
@@ -41,6 +43,14 @@ export const MessageModel = types
     get data(): MessageData {
       const embeds = self.embeds.flatMap(embed => embed.data)
 
+      let flags = 0
+      if (self.flags_suppress_embeds) {
+        flags |= 1 << 2
+      }
+      if (self.flags_suppress_notifications) {
+        flags |= 1 << 12
+      }
+
       return {
         content: self.content || null,
         embeds: embeds.length > 0 ? embeds : null,
@@ -49,6 +59,7 @@ export const MessageModel = types
         files: self.files.length > 0 ? Array.from(self.files) : undefined,
         attachments: self.files.length === 0 ? [] : undefined,
         thread_name: self.thread_name || undefined,
+        flags: flags === 0 ? undefined : flags,
       }
     },
 


### PR DESCRIPTION
I'm a bit worried that people will enable "suppress embeds" and then wonder why their embeds aren't showing. Hope that's not too common.

Docs PR for silent messages: https://github.com/discord/discord-api-docs/pull/5910
Also pending a preview tab update that shows when the message is silent.