### PR TITLE
Loud send/edit errors

### DIFF
--- a/modules/editor/EditorManager.ts
+++ b/modules/editor/EditorManager.ts
@@ -64,7 +64,7 @@ export const EditorManager = types
     },
 
     async save() {
-      const errors: DiscordError[] = [];
+      const errors: DiscordError[] = []
       for (const target of self.targets) {
         for (const message of self.messages) {
           const headers: Record<string, string> = {
@@ -101,7 +101,7 @@ export const EditorManager = types
           /* eslint-enable no-await-in-loop */
 
           if (!response.ok) {
-            errors.push(data as DiscordError);
+            errors.push(data as DiscordError)
           }
 
           console.log("Target executed", data)

--- a/modules/editor/EditorManager.ts
+++ b/modules/editor/EditorManager.ts
@@ -5,6 +5,7 @@ import { delay } from "../../common/state/delay"
 import type { MessageData } from "../message/state/data/MessageData"
 import { MessageModel } from "../message/state/models/MessageModel"
 import { WebhookModel } from "../webhook/WebhookModel"
+import type { DiscordError } from "../../types/DiscordError"
 
 export const EditorManager = types
   .model("EditorManager", {
@@ -63,6 +64,7 @@ export const EditorManager = types
     },
 
     async save() {
+      const errors: DiscordError[] = [];
       for (const target of self.targets) {
         for (const message of self.messages) {
           const headers: Record<string, string> = {
@@ -98,10 +100,17 @@ export const EditorManager = types
 
           /* eslint-enable no-await-in-loop */
 
+          if (!response.ok) {
+            errors.push(data as DiscordError);
+          }
+
           console.log("Target executed", data)
         }
       }
 
+      if (errors.length > 0) {
+        throw new Error(JSON.stringify(errors))
+      }
       return null
     },
 

--- a/modules/editor/EditorManager.ts
+++ b/modules/editor/EditorManager.ts
@@ -2,10 +2,10 @@
 
 import { Instance, SnapshotOrInstance, types } from "mobx-state-tree"
 import { delay } from "../../common/state/delay"
+import type { DiscordError } from "../../types/DiscordError"
 import type { MessageData } from "../message/state/data/MessageData"
 import { MessageModel } from "../message/state/models/MessageModel"
 import { WebhookModel } from "../webhook/WebhookModel"
-import type { DiscordError } from "../../types/DiscordError"
 
 export const EditorManager = types
   .model("EditorManager", {

--- a/modules/editor/webhook/DiscordErrorsModal.tsx
+++ b/modules/editor/webhook/DiscordErrorsModal.tsx
@@ -9,8 +9,8 @@ import { ModalTitle } from "../../../common/modal/layout/ModalTitle"
 import { ModalContext } from "../../../common/modal/ModalContext"
 import { useRequiredContext } from "../../../common/state/useRequiredContext"
 import { remove } from "../../../icons/remove"
-import { Markdown } from "../../markdown/Markdown"
 import type { CodedError, DiscordError } from "../../../types/DiscordError"
+import { Markdown } from "../../markdown/Markdown"
 
 export type DiscordErrorsModalProps = {
   errors: DiscordError[];
@@ -57,11 +57,7 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
         />
       </ModalHeader>
       <ModalBody>
-        <Markdown
-          content={
-            flattened.join('\n')
-          }
-        />
+        <Markdown content={flattened.join("\n")} />
       </ModalBody>
       <ModalFooter>
         <SecondaryButton onClick={() => modal.dismiss()}>Close</SecondaryButton>

--- a/modules/editor/webhook/DiscordErrorsModal.tsx
+++ b/modules/editor/webhook/DiscordErrorsModal.tsx
@@ -13,7 +13,7 @@ import type { CodedError, DiscordError } from "../../../types/DiscordError"
 import { Markdown } from "../../markdown/Markdown"
 
 export type DiscordErrorsModalProps = {
-  errors: DiscordError[];
+  errors: DiscordError[]
 }
 
 export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
@@ -21,9 +21,9 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
 
   const modal = useRequiredContext(ModalContext)
 
-  const flattened = errors.map((discordError) => {
+  const flattened = errors.map(discordError => {
     const flattenErrorObject = (d: DiscordError["errors"], key?: string) => {
-      const items: string[][] = [];
+      const items: string[][] = []
       for (const [k, v] of Object.entries(d)) {
         const newKey = key ? `${key}.${k}` : k
 
@@ -31,7 +31,9 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
           // eslint-disable-next-line no-underscore-dangle
           const codedErrors = (v as { _errors?: CodedError[] })._errors
           if (!codedErrors) {
-            items.push(...flattenErrorObject(v as DiscordError["errors"], newKey))
+            items.push(
+              ...flattenErrorObject(v as DiscordError["errors"], newKey),
+            )
           } else {
             items.push([newKey, codedErrors.map(e => e.message).join(", ")])
           }

--- a/modules/editor/webhook/DiscordErrorsModal.tsx
+++ b/modules/editor/webhook/DiscordErrorsModal.tsx
@@ -1,0 +1,71 @@
+import React from "react"
+import { SecondaryButton } from "../../../common/input/button/SecondaryButton"
+import { ModalAction } from "../../../common/modal/layout/ModalAction"
+import { ModalBody } from "../../../common/modal/layout/ModalBody"
+import { ModalContainer } from "../../../common/modal/layout/ModalContainer"
+import { ModalFooter } from "../../../common/modal/layout/ModalFooter"
+import { ModalHeader } from "../../../common/modal/layout/ModalHeader"
+import { ModalTitle } from "../../../common/modal/layout/ModalTitle"
+import { ModalContext } from "../../../common/modal/ModalContext"
+import { useRequiredContext } from "../../../common/state/useRequiredContext"
+import { remove } from "../../../icons/remove"
+import { Markdown } from "../../markdown/Markdown"
+import type { CodedError, DiscordError } from "../../../types/DiscordError"
+
+export type DiscordErrorsModalProps = {
+  errors: DiscordError[];
+}
+
+export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
+  const { errors } = props
+
+  const modal = useRequiredContext(ModalContext)
+
+  const flattened = errors.map((discordError) => {
+    const flattenErrorObject = (d: DiscordError["errors"], key?: string) => {
+      const items: string[][] = [];
+      for (const [k, v] of Object.entries(d)) {
+        const newKey = key ? `${key}.${k}` : k
+
+        if (typeof v === "object" && !Array.isArray(v) && v != null) {
+          // eslint-disable-next-line no-underscore-dangle
+          const codedErrors = (v as { _errors?: CodedError[] })._errors
+          if (!codedErrors) {
+            items.push(...flattenErrorObject(v as DiscordError["errors"], newKey))
+          } else {
+            items.push([newKey, codedErrors.map(e => e.message).join(", ")])
+          }
+        } else {
+          items.push([newKey, String(v)])
+        }
+      }
+
+      return items
+    }
+    const items = flattenErrorObject(discordError.errors)
+    return items.map(([k, v]) => `In \`${k}\`: ${v}`)
+  })[0]
+
+  return (
+    <ModalContainer>
+      <ModalHeader>
+        <ModalTitle>Discord Error</ModalTitle>
+        <ModalAction
+          icon={remove}
+          label="Close"
+          onClick={() => modal.dismiss()}
+        />
+      </ModalHeader>
+      <ModalBody>
+        <Markdown
+          content={
+            flattened.join('\n')
+          }
+        />
+      </ModalBody>
+      <ModalFooter>
+        <SecondaryButton onClick={() => modal.dismiss()}>Close</SecondaryButton>
+      </ModalFooter>
+    </ModalContainer>
+  )
+}

--- a/modules/editor/webhook/DiscordErrorsModal.tsx
+++ b/modules/editor/webhook/DiscordErrorsModal.tsx
@@ -24,7 +24,7 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
   const flattened = errors.map(discordError => {
     const flattenErrorObject = (d: DiscordError["errors"], key?: string) => {
       const items: string[][] = []
-      for (const [k, v] of Object.entries(d)) {
+      for (const [k, v] of Object.entries(d!)) {
         const newKey = key ? `${key}.${k}` : k
 
         if (typeof v === "object" && !Array.isArray(v) && v != null) {
@@ -44,8 +44,11 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
 
       return items
     }
-    const items = flattenErrorObject(discordError.errors)
-    return items.map(([k, v]) => `In \`${k}\`: ${v}`)
+    if (discordError.errors) {
+      const items = flattenErrorObject(discordError.errors)
+      return items.map(([k, v]) => `In \`${k}\`: ${v}`)
+    }
+    return [discordError.message]
   })[0]
 
   return (

--- a/modules/editor/webhook/DiscordErrorsModal.tsx
+++ b/modules/editor/webhook/DiscordErrorsModal.tsx
@@ -59,7 +59,11 @@ export function DiscordErrorsModal(props: DiscordErrorsModalProps) {
         />
       </ModalHeader>
       <ModalBody>
-        <Markdown content={flattened.join("\n")} />
+        <Markdown
+          content={`Your message could not be submitted because it contains the following errors:\n\n${flattened.join(
+            "\n",
+          )}`}
+        />
       </ModalBody>
       <ModalFooter>
         <SecondaryButton onClick={() => modal.dismiss()}>Close</SecondaryButton>

--- a/modules/editor/webhook/WebhookControls.tsx
+++ b/modules/editor/webhook/WebhookControls.tsx
@@ -12,8 +12,8 @@ import { useRequiredContext } from "../../../common/state/useRequiredContext"
 import { remove } from "../../../icons/remove"
 import type { EditorFormState } from "../../message/state/editorForm"
 import { EditorManagerContext } from "../EditorManagerContext"
-import { NetworkErrorModal } from "./NetworkErrorModal"
 import { DiscordErrorsModal } from "./DiscordErrorsModal"
+import { NetworkErrorModal } from "./NetworkErrorModal"
 
 const InputAction = styled(IconButton)`
   margin-left: 8px;

--- a/modules/editor/webhook/WebhookControls.tsx
+++ b/modules/editor/webhook/WebhookControls.tsx
@@ -13,6 +13,7 @@ import { remove } from "../../../icons/remove"
 import type { EditorFormState } from "../../message/state/editorForm"
 import { EditorManagerContext } from "../EditorManagerContext"
 import { NetworkErrorModal } from "./NetworkErrorModal"
+import { DiscordErrorsModal } from "./DiscordErrorsModal"
 
 const InputAction = styled(IconButton)`
   margin-left: 8px;
@@ -39,11 +40,17 @@ export function WebhookControls(props: WebhookControlsProps) {
     setSubmitting(true)
 
     try {
-      await form.save()
-    } catch {
-      modalManager.spawn({
-        render: () => <NetworkErrorModal />,
-      })
+      await form.save();
+    } catch (error) {
+      if (error instanceof TypeError) {
+        modalManager.spawn({
+          render: () => <NetworkErrorModal />,
+        })
+      } else {
+        modalManager.spawn({
+          render: () => <DiscordErrorsModal errors={JSON.parse((error as Error).message)} />,
+        })
+      }
     }
 
     setSubmitting(false)

--- a/modules/editor/webhook/WebhookControls.tsx
+++ b/modules/editor/webhook/WebhookControls.tsx
@@ -40,7 +40,7 @@ export function WebhookControls(props: WebhookControlsProps) {
     setSubmitting(true)
 
     try {
-      await form.save();
+      await form.save()
     } catch (error) {
       if (error instanceof TypeError) {
         modalManager.spawn({
@@ -48,7 +48,9 @@ export function WebhookControls(props: WebhookControlsProps) {
         })
       } else {
         modalManager.spawn({
-          render: () => <DiscordErrorsModal errors={JSON.parse((error as Error).message)} />,
+          render: () => (
+            <DiscordErrorsModal errors={JSON.parse((error as Error).message)} />
+          ),
         })
       }
     }

--- a/types/DiscordError.ts
+++ b/types/DiscordError.ts
@@ -1,11 +1,11 @@
 // >= v8
 export type DiscordError = {
-  code: number;
-  message: string;
-  errors: Record<string, unknown>;
+  code: number
+  message: string
+  errors: Record<string, unknown>
 }
 
 export type CodedError = {
-  code: string;
-  message: string;
+  code: string
+  message: string
 }

--- a/types/DiscordError.ts
+++ b/types/DiscordError.ts
@@ -1,0 +1,11 @@
+// >= v8
+export type DiscordError = {
+  code: number;
+  message: string;
+  errors: Record<string, unknown>;
+}
+
+export type CodedError = {
+  code: string;
+  message: string;
+}

--- a/types/DiscordError.ts
+++ b/types/DiscordError.ts
@@ -2,7 +2,7 @@
 export type DiscordError = {
   code: number
   message: string
-  errors: Record<string, unknown>
+  errors?: Record<string, unknown>
 }
 
 export type CodedError = {


### PR DESCRIPTION
In the event that the user attempts to submit despite the user-friendly warnings already on the site (or there is a violation it doesn't check for), this new modal exposes errors returned by Discord in the request. Seeing as most cases are already covered by the site, this is intended to never be seen and as such I thought the "technical" phrasing (like the zero-indexed embeds) was fine.

https://github.com/discohook/site/assets/43248357/e5abc0ad-19a6-408b-a85e-c6f44c03c957