### PR TITLE
Update README.md, explain running container, specify node 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,19 @@ An easy-to-use tool for building and sending Discord messages and embeds using w
 
 Live instance is available at <https://discohook.app/>.
 
-## Setup
+## Running via Container
 
-Requires Node.js 12 and the Yarn package manager installed
+This application is setup to publish a container image to `ghcr.io/discohook/site:latest`. This image can be run with [podman](https://podman.io/), [docker](https://www.docker.com/), or another service compliant with the [OCI](https://opencontainers.org/). The image can be run from the command line with the following command or in the desktop guis ([podman desktop guide](https://podman-desktop.io/docs/working-with-containers/starting-a-container))
+```sh
+# Replace 'podman' with 'docker' if using that, the command is equivalent
+# Add --rm if you want the container to be removed automatically after being stopped
+# If necesary, change the second 3000 to change which port on the local computer the app is bound to
+podman run -dtp 3000:3000 ghcr.io/discohook/site:latest
+```
+
+## Local build and run
+
+Requires Node.js 16 and the Yarn package manager installed
 
 ```sh
 # Install dependencies

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This application is setup to publish a container image to `ghcr.io/discohook/sit
 # Replace 'podman' with 'docker' if using that, the command is equivalent
 # Add --rm if you want the container to be removed automatically after being stopped
 # If necesary, change the second 3000 to change which port on the local computer the app is bound to
-podman run -dtp 3000:3000 ghcr.io/discohook/site:latest
+podman run -d -p 3000:3000 ghcr.io/discohook/site:latest
 ```
 
 ## Local build and run


### PR DESCRIPTION
Update README.md to explain running via published container and specified node version 16 to match the version used by the CI image

Wanted to try and make this as simple as possible for people to self host in the event the site ever goes down